### PR TITLE
Add react-router template option

### DIFF
--- a/src/types/cli.d.ts
+++ b/src/types/cli.d.ts
@@ -1,0 +1,4 @@
+export interface TemplateOptions {
+  label: string;
+  value: string;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,5 @@
+import type { TemplateOptions } from '../types/cli';
+
 export const DEFAULT_REGISTRY = 'https://raw.githubusercontent.com/xeikit/starter/templates/templates' as const;
 export const DEFAULT_TEMPLATE_NAME = 'nuxt3' as const;
 export const PACKAGE_MANAGERS = {
@@ -8,4 +10,7 @@ export const PACKAGE_MANAGERS = {
   deno: undefined,
 } as const;
 export const PACKAGE_MANAGER_OPTIONS = Object.keys(PACKAGE_MANAGERS) as Array<keyof typeof PACKAGE_MANAGERS>;
-export const TEMPLATE_OPTIONS = [{ label: 'Nuxt3', value: 'nuxt3' }];
+export const TEMPLATE_OPTIONS = [
+  { label: 'Nuxt3', value: 'nuxt3' },
+  { label: 'React Router (framework)', value: 'react-router' },
+] satisfies TemplateOptions[];


### PR DESCRIPTION
close #8 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new template option for "React Router (framework)" alongside the existing Nuxt3 option when selecting templates.

- **Refactor**
  - Improved type safety for template options to ensure consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->