### PR TITLE
Update DEFAULT_REGISTRY URL to official xeikit starter-templates repository

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,7 +4,7 @@ import type { TemplateOptions } from '../types/cli';
  * Default registry URL for downloading project templates.
  * Points to the official xeikit starter templates repository.
  */
-export const DEFAULT_REGISTRY = 'https://raw.githubusercontent.com/xeikit/starter/templates/templates' as const;
+export const DEFAULT_REGISTRY = 'https://raw.githubusercontent.com/xeikit/starter-templates/main/templates' as const;
 
 /**
  * Default template name used when no template is specified.


### PR DESCRIPTION
close #14 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default source URL for downloading project templates to a new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->